### PR TITLE
Check If Driver

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -839,11 +839,13 @@ Citizen.CreateThread(function()
                         if not isPlyInBennys then
                             Draw3DText(v.coords.x, v.coords.y, v.coords.z + 0.5, "[Press ~p~E~w~ - Enter Benny's Motorworks]", 255, 255, 255, 255, 4, 0.45, true, true, true, true, 0, 0, 0, 0, 55)
                             if IsControlJustReleased(1, 38) then
-                                if (v.useJob and isAuthorized((QBCore.Functions.GetPlayerData().job.name), k)) or not v.useJob then
-                                    TriggerEvent('event:control:bennys', k)
-                                else
-                                    QBCore.Functions.Notify("You are not authorized", "error")
-                                end
+				if GetPedInVehicleSeat(GetVehiclePedIsIn(PlayerPedId()), -1) == PlayerPedId() then
+					if (v.useJob and isAuthorized((QBCore.Functions.GetPlayerData().job.name), k)) or not v.useJob then
+					    TriggerEvent('event:control:bennys', k)
+					else
+					    QBCore.Functions.Notify("You are not authorized", "error")
+					end
+				end
                             end
                         else
                             disableControls()


### PR DESCRIPTION
Fixes #35 

Check if player is driving before opening menu
Have placed after the ControlPressed so as not to add any performance in the loop. The check will only occur once you press E, this means that the 3DText & Marker will still appear if in another seat.