### PR TITLE
[Update] Polyzone Update + Hotfixes + More

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -129,9 +129,7 @@ function RepairVehicle()
     SetVehiclePetrolTankHealth(plyVeh, 4000.0)
     SetVehicleFuelLevel(plyVeh, getFuel)
 
-    for i = 0,5 do SetVehicleTyreFixed(vehicle, i) end
-
-    TriggerEvent('veh.randomDegredation',10,plyVeh,3)
+    for i = 0,5 do SetVehicleTyreFixed(plyVeh, i) end
 end
 
 function GetCurrentMod(id)
@@ -694,7 +692,6 @@ function ApplyNeonColour(r, g, b)
     originalNeonColourB = b
 
     SetVehicleNeonLightsColour(plyVeh, r, g, b)
-    originalXenonState = state
 end
 
 function ApplyXenonLights(category, state)

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -749,7 +749,9 @@ function ExitBennys()
         DestroyMenus()
     end)
 
-    SetupInteraction()
+    if next(CustomsData) then
+        SetupInteraction()
+    end
 
     isPlyInBennys = false
 end
@@ -779,7 +781,7 @@ function EnterLocation(override)
             if not canEnter and v then canEnter = true end
             categories[k] = v
         end
-    end
+    elseif override then canEnter = true end
 
     if not canEnter then 
         QBCore.Functions.Notify('You cant do anything here!')

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -90,6 +90,9 @@ function RepairVehicle()
 	SetVehicleDirtLevel(plyVeh, 0.0)
     SetVehiclePetrolTankHealth(plyVeh, 4000.0)
     SetVehicleFuelLevel(plyVeh, getFuel)
+
+    for i = 0,5 do SetVehicleTyreFixed(vehicle, i) end
+
     TriggerEvent('veh.randomDegredation',10,plyVeh,3)
 end
 
@@ -792,13 +795,13 @@ CreateThread(function()
                         if not isPlyInBennys then
                             Draw3DText(v.coords.x, v.coords.y, v.coords.z + 0.5, "[Press ~p~E~w~ - Enter Benny's Motorworks]", 255, 255, 255, 255, 4, 0.45, true, true, true, true, 0, 0, 0, 0, 55)
                             if IsControlJustReleased(1, 38) then
-				if GetPedInVehicleSeat(GetVehiclePedIsIn(PlayerPedId()), -1) == PlayerPedId() then
-					if (v.useJob and isAuthorized((QBCore.Functions.GetPlayerData().job.name), k)) or not v.useJob then
-					    TriggerEvent('event:control:bennys', k)
-					else
-					    QBCore.Functions.Notify("You are not authorized", "error")
-					end
-				end
+                                if GetPedInVehicleSeat(GetVehiclePedIsIn(PlayerPedId()), -1) == PlayerPedId() then
+                                    if (v.useJob and isAuthorized((QBCore.Functions.GetPlayerData().job.name), k)) or not v.useJob then
+                                        TriggerEvent('event:control:bennys', k)
+                                    else
+                                        QBCore.Functions.Notify("You are not authorized", "error")
+                                    end
+                                end
                             end
                         else
                             disableControls()

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -853,6 +853,12 @@ function DisableControls()
     end)
 end
 
+function GetLocations()
+    QBCore.Functions.TriggerCallback("qb-customs:server:GetLocations", function(locations)
+        Config.Locations = locations
+    end)
+end
+
 exports('GetCustomsData', function() if next(CustomsData) ~= nil then return CustomsData else return nil end end)
 -----------------------
 ----   Threads     ----
@@ -908,9 +914,9 @@ end)
 -----------------------
 
 AddEventHandler('onResourceStart', function(resourceName)
-	if resourceName == GetCurrentResourceName() and QBCore.Functions.GetPlayerData() == {} then
-		PlayerData = QBCore.Functions.GetPlayerData()
-	end
+    if resourceName == GetCurrentResourceName() and QBCore.Functions.GetPlayerData() ~= {} then
+        GetLocations()
+    end
 end)
 
 AddEventHandler("onResourceStop", function(resource)
@@ -921,9 +927,7 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     PlayerData = QBCore.Functions.GetPlayerData()
-    QBCore.Functions.TriggerCallback("inventory:server:GetCurrentDrops", function(locations)
-        Config.Locations = locations
-    end)
+    GetLocations()
 end)
 
 RegisterNetEvent('QBCore:Client:OnGangUpdate', function(gang)

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -860,7 +860,7 @@ exports('GetCustomsData', function() if next(CustomsData) ~= nil then return Cus
 
 -- Location Creation
 CreateThread(function()
-    while not PlayerData.job do Wait(2500) end 
+    while not PlayerData.job do Wait(2500) end
     for location, data in pairs(Config.Locations) do
         -- PolyZone + Drawtext + Locations Management
         for i, spot in ipairs(data.zones) do
@@ -871,7 +871,6 @@ CreateThread(function()
                 heading = spot.heading,
                 minZ = spot.minZ,
                 maxZ = spot.maxZ,
-                data = { name = garage }
             })
 
             newSpot:onPlayerInOut(function(isPointInside, point)
@@ -883,9 +882,10 @@ CreateThread(function()
                 local allowedGang = AllowGang(restrictions, PlayerData.gang.name)
                 local allowedClass = AllowVehicleClass(restrictions, GetVehiclePedIsIn(PlayerPedId(), false))
 
-                if isPointInside and isEnabled and allowedJob and allowedGang and allowedClass then 
+                if isPointInside and isEnabled and allowedJob and allowedGang and allowedClass then
                     CustomsData = {
                         ['location'] = location,
+                        ['spot'] = _name,
                         ['coords'] = vector3(spot.coords.x, spot.coords.y, spot.coords.z),
                         ['heading'] = spot.heading
                     }

--- a/client/cl_ui.lua
+++ b/client/cl_ui.lua
@@ -249,14 +249,16 @@ function InitiateMenus(isMotorcycle, vehicleHealth)
     --#[Main Menu]#--
     createMenu("mainMenu", "Welcome to Benny's Original Motorworks", "Choose a Category")
 
-    for k, v in ipairs(vehicleCustomisation) do
-        local validMods, amountValidMods = CheckValidMods(v.category, v.id)
-
-        if amountValidMods > 0 or v.id == 18 then
-            populateMenu("mainMenu", v.id, v.category, "none")
+    if maxVehiclePerformanceUpgrades ~= -1 then
+        for k, v in ipairs(vehicleCustomisation) do
+            local validMods, amountValidMods = CheckValidMods(v.category, v.id)
+    
+            if amountValidMods > 0 or v.id == 18 then
+                populateMenu("mainMenu", v.id, v.category, "none")
+            end
         end
     end
-
+    
     populateMenu("mainMenu", -1, "Respray", "none")
 
     if not isMotorcycle then
@@ -267,7 +269,12 @@ function InitiateMenus(isMotorcycle, vehicleHealth)
     populateMenu("mainMenu", 22, "Xenons", "none")
     populateMenu("mainMenu", 23, "Wheels", "none")
 
-    populateMenu("mainMenu", 24, "Old Livery", "none")
+    local livCount = GetVehicleLiveryCount(plyVeh)
+    print(livCount)
+    if livCount > 0 then
+        populateMenu("mainMenu", 24, "Old Livery", "none")
+    end
+
     populateMenu("mainMenu", 25, "Plate Index", "none")
     populateMenu("mainMenu", 26, "Vehicle Extras", "none")
 
@@ -446,16 +453,14 @@ function InitiateMenus(isMotorcycle, vehicleHealth)
     finishPopulatingMenu("WindowTintMenu")
 
     --#[Old Livery Menu]#--
-    local livCount = GetVehicleLiveryCount(plyVeh)
     if livCount > 0 then
         local tempOldLivery = GetVehicleLivery(plyVeh)
+        
         createMenu("OldLiveryMenu", "Old Livery Customisation", "Choose a Livery")
-        if GetVehicleClass(plyVeh) ~= 18 then
-            for i=0, GetVehicleLiveryCount(plyVeh)-1 do
-                populateMenu("OldLiveryMenu", i, "Livery", "$100")
-                if tempOldLivery == i then
-                    updateItem2Text("OldLiveryMenu", i, "Installed")
-                end
+        for i=0, GetVehicleLiveryCount(plyVeh)-1 do
+            populateMenu("OldLiveryMenu", i, "Livery", "$100")
+            if tempOldLivery == i then
+                updateItem2Text("OldLiveryMenu", i, "Installed")
             end
         end
         finishPopulatingMenu("OldLiveryMenu")
@@ -473,13 +478,11 @@ function InitiateMenus(isMotorcycle, vehicleHealth)
         "Blue on White #3",
         "North Yankton",
     }
-    if GetVehicleClass(plyVeh) ~= 18 then
-        for i=0, #plateTypes-1 do
-            if i ~= 4 then
-                populateMenu("PlateIndexMenu", i, plateTypes[i+1], "$1000")
-                if tempPlateIndex == i then
-                    updateItem2Text("PlateIndexMenu", i, "Installed")
-                end
+    for i=0, #plateTypes-1 do
+        if i ~= 4 then
+            populateMenu("PlateIndexMenu", i, plateTypes[i+1], "$1000")
+            if tempPlateIndex == i then
+                updateItem2Text("PlateIndexMenu", i, "Installed")
             end
         end
     end
@@ -487,13 +490,11 @@ function InitiateMenus(isMotorcycle, vehicleHealth)
 
     --#[Vehicle Extras Menu]#--
     createMenu("VehicleExtrasMenu", "Vehicle Extras Customisation", "Toggle Extras")
-    if GetVehicleClass(plyVeh) ~= 18 then
-        for i=1, 12 do
-            if DoesExtraExist(plyVeh, i) then
-                populateMenu("VehicleExtrasMenu", i, "Extra "..tostring(i), "Toggle")
-            else
-                populateMenu("VehicleExtrasMenu", i, "No Option", "NONE")
-            end
+    for i=1, 12 do
+        if DoesExtraExist(plyVeh, i) then
+            populateMenu("VehicleExtrasMenu", i, "Extra "..tostring(i), "Toggle")
+        else
+            populateMenu("VehicleExtrasMenu", i, "No Option", "NONE")
         end
     end
     finishPopulatingMenu("VehicleExtrasMenu")
@@ -797,28 +798,24 @@ function MenuManager(state)
                 elseif currentMenu == "OldLiveryMenu" then
                     local plyPed = PlayerPedId()
                     local plyVeh = GetVehiclePedIsIn(plyPed, false)
-                    if GetVehicleClass(plyVeh) ~= 18 then
-                        if AttemptPurchase("oldlivery") then
-                            ApplyOldLivery(currentMenuItemID)
-                            playSoundEffect("wrench", 0.4)
-                            updateItem2Text(currentMenu, currentMenuItemID, "Installed")
-                            updateMenuStatus("Purchased")
-                        else
-                            updateMenuStatus("Not Enough Money")
-                        end
+                    if AttemptPurchase("oldlivery") then
+                        ApplyOldLivery(currentMenuItemID)
+                        playSoundEffect("wrench", 0.4)
+                        updateItem2Text(currentMenu, currentMenuItemID, "Installed")
+                        updateMenuStatus("Purchased")
+                    else
+                        updateMenuStatus("Not Enough Money")
                     end
                 elseif currentMenu == "PlateIndexMenu" then
                     local plyPed = PlayerPedId()
                     local plyVeh = GetVehiclePedIsIn(plyPed, false)
-                    if GetVehicleClass(plyVeh) ~= 18 then
-                        if AttemptPurchase("plateindex") then
-                            ApplyPlateIndex(currentMenuItemID)
-                            playSoundEffect("wrench", 0.4)
-                            updateItem2Text(currentMenu, currentMenuItemID, "Installed")
-                            updateMenuStatus("Purchased")
-                        else
-                            updateMenuStatus("Not Enough Money")
-                        end
+                    if AttemptPurchase("plateindex") then
+                        ApplyPlateIndex(currentMenuItemID)
+                        playSoundEffect("wrench", 0.4)
+                        updateItem2Text(currentMenu, currentMenuItemID, "Installed")
+                        updateMenuStatus("Purchased")
+                    else
+                        updateMenuStatus("Not Enough Money")
                     end
                 elseif currentMenu == "VehicleExtrasMenu" then
                     ApplyExtra(currentMenuItemID)
@@ -899,10 +896,10 @@ function MenuManager(state)
 
                 local plyPed = PlayerPedId()
                 local plyVeh = GetVehiclePedIsIn(plyPed, false)
-                if currentMenu == "OldLiveryMenu" and GetVehicleClass(plyVeh) ~= 18 then
+                if currentMenu == "OldLiveryMenu" then
                     RestoreOldLivery()
                 end
-                if currentMenu == "PlateIndexMenu" and GetVehicleClass(plyVeh) ~= 18 then
+                if currentMenu == "PlateIndexMenu" then
                     RestorePlateIndex()
                 end
 

--- a/client/cl_ui.lua
+++ b/client/cl_ui.lua
@@ -211,7 +211,7 @@ function InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
     if vehicleHealth < 1000.0 and categories.repair then
         local repairCost = math.ceil(1000 - vehicleHealth)
 
-        TriggerServerEvent("qb-customs:client:updateRepairCost", repairCost)
+        TriggerServerEvent("qb-customs:server:updateRepairCost", repairCost)
         createMenu("repairMenu", welcomeLabel, "Repair Vehicle")
         populateMenu("repairMenu", -1, "Repair", "$" .. repairCost)
         finishPopulatingMenu("repairMenu")
@@ -220,28 +220,32 @@ function InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
     --#[Main Menu]#--
     createMenu("mainMenu", welcomeLabel, "Choose a Category")
 
-    if maxVehiclePerformanceUpgrades ~= -1 then
-        for k, v in ipairs(vehicleCustomisation) do
-            local validMods, amountValidMods = CheckValidMods(v.category, v.id)
-    
-            if amountValidMods > 0 or v.id == 18 or v.id == 48 then
-                if (v.id == 11 or v.id == 12 or v.id == 13 or v.id == 15 or v.id == 16) and categories.mods then
-                    populateMenu("mainMenu", v.id, v.category, "none")
-                elseif v.id == 14 and categories.horn then
-                    populateMenu("mainMenu", v.id, v.category, "none")
-                elseif v.id == 16 and categories.armor then
-                    populateMenu("mainMenu", v.id, v.category, "none")
-                elseif v.id == 18 and categories.turbo then
-                    populateMenu("mainMenu", v.id, v.category, "none")
-                elseif v.id == 48 and categories.respray then
-                    populateMenu("mainMenu", v.id, v.category, "none")
-                else
+    for _, v in ipairs(vehicleCustomisation) do
+        local _, amountValidMods = CheckValidMods(v.category, v.id)
+        
+        if amountValidMods > 0 or v.id == 18 then
+            if (v.id == 11 or v.id == 12 or v.id == 13 or v.id == 15 or v.id == 16) then
+                if categories.mods and maxVehiclePerformanceUpgrades ~= -1 then
                     populateMenu("mainMenu", v.id, v.category, "none")
                 end
+            elseif v.id == 14 then
+                if categories.horns then
+                    populateMenu("mainMenu", v.id, v.category, "none")
+                end
+            elseif v.id == 18 then
+                if categories.turbo then
+                    populateMenu("mainMenu", v.id, v.category, "none")
+                end
+            elseif v.id == 48 then
+                if categories.liveries then
+                    populateMenu("mainMenu", v.id, v.category, "none")
+                end
+            else
+                populateMenu("mainMenu", v.id, v.category, "none")
             end
         end
     end
-    
+
     if categories.respray then populateMenu("mainMenu", -1, "Respray", "none") end
 
     if not isMotorcycle then
@@ -460,8 +464,8 @@ function InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
         "North Yankton",
     }
     for i=0, #plateTypes-1 do
-        if i ~= 4 then
-            populateMenu("PlateIndexMenu", i, plateTypes[i+1], "$1000")
+        if i ~= 4 or (i == 4 and GetVehicleClass(plyVeh) == 18) or Config.allowGovPlateIndex then
+            populateMenu("PlateIndexMenu", i, plateTypes[i+1], "$"..vehicleCustomisationPrices.plateindex.price)
             if tempPlateIndex == i then
                 updateItem2Text("PlateIndexMenu", i, "Installed")
             end

--- a/config.lua
+++ b/config.lua
@@ -81,7 +81,8 @@ vehicleWheelOptions = {
     {category = "BennysWheel", id = 8, wheelID = 23},
     {category = "BespokeWheel", id = 9, wheelID = 23},
     {category = "Dragster", id = 10, wheelID = 23},
-    {category = "Street", id = 11, wheelID = 23}
+    {category = "Street", id = 11, wheelID = 23},
+    {category = "Rally", id = 12, wheelID = 23},
 }
 
 -- TIRE SMOKE

--- a/config.lua
+++ b/config.lua
@@ -2,6 +2,8 @@ Config = Config or {}
 
 Config.MoneyType = 'bank'
 Config.RepairMoneyType = 'cash'
+Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
+Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 
 maxVehiclePerformanceUpgrades = -1 -- Set to 0 to have all the upgrades
 vehicleBaseRepairCost = 600

--- a/config.lua
+++ b/config.lua
@@ -1,22 +1,13 @@
-maxVehiclePerformanceUpgrades = 0 -- Set to 0 to have all the upgrades
+Config = Config or {}
+
+Config.MoneyType = 'bank'
+Config.RepairMoneyType = 'cash'
+
+maxVehiclePerformanceUpgrades = -1 -- Set to 0 to have all the upgrades
 vehicleBaseRepairCost = 600
 vehicleRepairCostMultiplier = 1
-moneyType = 'bank'
-
--- Location Configs
--- Add locations here
--- Add jobs specific to the garage.
-bennyGarages = {
-    [1] = {coords = vector4(-211.55, -1324.55, 30.90, 319.73135375977), blip = true, useJob = false, job = {"mechanic", "police"}},
-    [2] = {coords = vector4(109.89, 6627.07, 31.78, 221.7938), blip = true, useJob = true, job = {"mechanic"}}
-}
-
---[[ bennyLocations = {
-    vector4(-211.55, -1324.55, 30.90, 319.731)
-} ]]
 
 -- ADJUST PRICING
-
 vehicleCustomisationPrices = {
     cosmetics = {price = 400},
     respray = {price = 1000},

--- a/config.lua
+++ b/config.lua
@@ -77,7 +77,11 @@ vehicleWheelOptions = {
     {category = "Offroad", id = 4, wheelID = 23},
     {category = "Tuner", id = 5, wheelID = 23},
     {category = "Motorcycle", id = 6, wheelID = 23},
-    {category = "Highend", id = 7, wheelID = 23}
+    {category = "Highend", id = 7, wheelID = 23},
+    {category = "BennysWheel", id = 8, wheelID = 23},
+    {category = "BespokeWheel", id = 9, wheelID = 23},
+    {category = "Dragster", id = 10, wheelID = 23},
+    {category = "Street", id = 11, wheelID = 23}
 }
 
 -- TIRE SMOKE

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,11 +11,16 @@ files {
     'html/sounds/respray.ogg'
 }
 
-shared_script 'config.lua'
+shared_scripts {
+    'config.lua',
+    'shared/locations.lua',
+}
 
 client_scripts {
+    '@PolyZone/client.lua',
+    '@PolyZone/BoxZone.lua',
     'client/cl_ui.lua',
-    'client/cl_bennys.lua'
+    'client/cl_bennys.lua',
 }
 
 server_scripts {

--- a/html/js/ui.js
+++ b/html/js/ui.js
@@ -105,7 +105,7 @@ window.onload = function(e)
                 var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                 var val2 = $("." + menu + " .item_selected .item1").text();
                 var val3 = $("." + menu + " .item_selected .item2").text();
-                $.post("https://qb-customs/selectedItem", JSON.stringify({
+                $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                     id: val1,
                     item: val2,
                     item2: val3
@@ -131,7 +131,7 @@ window.onload = function(e)
                 var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                 var val2 = $("." + menu + " .item_selected .item1").text();
                 var val3 = $("." + menu + " .item_selected .item2").text();
-                $.post("https://qb-customs/selectedItem", JSON.stringify({
+                $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                     id: val1,
                     item: val2,
                     item2: val3
@@ -149,7 +149,7 @@ window.onload = function(e)
     function updateItem2TextOnly(menu, id, text)
     {
         $("." + menu + " ." + id + " .item2").text(text);
-        $.post("https://qb-customs/updateItem2", JSON.stringify({
+        $.post(`https://${GetParentResourceName()}/updateItem2`, JSON.stringify({
             item: text
         }));
     }
@@ -165,9 +165,17 @@ window.onload = function(e)
         else if(id != menuStructure[menu].previousSelectedItemID)
         {
             var prevID = menuStructure[menu].previousSelectedItemID
-
-            $("." + menu + " ." + prevID + " .item2").text(menuStructure[menu].items[prevID].item2);
-            menuStructure[menu].itemsArray[prevID + 1].getElementsByClassName("item2")[0].textContent = menuStructure[menu].items[prevID].item2;
+            if(menuStructure[menu].itemsArray[prevID] != undefined) {
+                $("." + menu + " ." + prevID + " .item2").text(menuStructure[menu].items[prevID].item2);
+                menuStructure[menu].itemsArray[prevID].getElementsByClassName("item2")[0].textContent = menuStructure[menu].items[prevID].item2;
+            } else {
+                for (let i = 0; i < menuStructure[menu].itemsArray.length; i++) {
+                    if(menuStructure[menu].itemsArray[i].classList.contains(prevID)) {
+                        $("." + menu + " ." + prevID + " .item2").text(menuStructure[menu].items[prevID].item2);
+                        menuStructure[menu].itemsArray[i].getElementsByClassName("item2")[0].textContent = menuStructure[menu].items[prevID].item2;
+                    }
+                }
+            }
             menuStructure[menu].previousSelectedItemID = id;
 
             $("." + menu + " .item_selected .item2").text(text);
@@ -179,7 +187,7 @@ window.onload = function(e)
             menuStructure[menu].previousSelectedItemID = null
         }
 
-        $.post("https://qb-customs/updateItem2", JSON.stringify({
+        $.post(`https://${GetParentResourceName()}/updateItem2`, JSON.stringify({
             item: text
         }));
     }
@@ -208,7 +216,7 @@ window.onload = function(e)
                     var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                     var val2 = $("." + menu + " .item_selected .item1").text();
                     var val3 = $("." + menu + " .item_selected .item2").text();
-                    $.post("https://qb-customs/selectedItem", JSON.stringify({
+                    $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                         id: val1,
                         item: val2,
                         item2: val3
@@ -231,7 +239,7 @@ window.onload = function(e)
                     var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                     var val2 = $("." + menu + " .item_selected .item1").text();
                     var val3 = $("." + menu + " .item_selected .item2").text();
-                    $.post("https://qb-customs/selectedItem", JSON.stringify({
+                    $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                         id: val1,
                         item: val2,
                         item2: val3
@@ -260,7 +268,7 @@ window.onload = function(e)
                     var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                     var val2 = $("." + menu + " .item_selected .item1").text();
                     var val3 = $("." + menu + " .item_selected .item2").text();
-                    $.post("https://qb-customs/selectedItem", JSON.stringify({
+                    $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                         id: val1,
                         item: val2,
                         item2: val3
@@ -294,7 +302,7 @@ window.onload = function(e)
                     var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                     var val2 = $("." + menu + " .item_selected .item1").text();
                     var val3 = $("." + menu + " .item_selected .item2").text();
-                    $.post("https://qb-customs/selectedItem", JSON.stringify({
+                    $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                         id: val1,
                         item: val2,
                         item2: val3
@@ -314,7 +322,7 @@ window.onload = function(e)
                     var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                     var val2 = $("." + menu + " .item_selected .item1").text();
                     var val3 = $("." + menu + " .item_selected .item2").text();
-                    $.post("https://qb-customs/selectedItem", JSON.stringify({
+                    $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                         id: val1,
                         item: val2,
                         item2: val3
@@ -338,7 +346,7 @@ window.onload = function(e)
                     var val1 = $("." + menu + " .item_selected").attr("class").split(" ")[0];
                     var val2 = $("." + menu + " .item_selected .item1").text();
                     var val3 = $("." + menu + " .item_selected .item2").text();
-                    $.post("https://qb-customs/selectedItem", JSON.stringify({
+                    $.post(`https://${GetParentResourceName()}/selectedItem`, JSON.stringify({
                         id: val1,
                         item: val2,
                         item2: val3

--- a/shared/locations.lua
+++ b/shared/locations.lua
@@ -1,0 +1,369 @@
+--[[ 
+    ['Innocence'] = {
+    settings = {
+        label = 'Bennys Motorworks', -- Text label for anything that wants it
+        welcomeLabel = "Welcome to Benny's Motorworks!", -- Welcome label in the UI
+        enabled = true, -- If the location can be used at all
+    },
+    blip = {
+        label = 'Bennys Motorworks',
+        coords = vector3(-205.6992, -1312.7377, 31.1588), 
+        sprite = 72,
+        scale = 0.65,
+        color = 0,
+        display = 4,
+        enabled = true,
+    },
+    categories = { -- Only include the categories you want. A category not listed defaults to FALSE.
+        repair = true, 
+        mods = true, 
+        armor = true,
+        respray = true, 
+        liveries = true,
+        wheels = true, 
+        tint = true, 
+        plate = true, 
+        extras = true, 
+        neons = true, 
+        xenons = true, 
+        horn = true, 
+        turbo = true,
+    },
+    drawtextui = { -- background1 and background2 are also valid options for the background gradiant
+        text = "Bennys Motorworks",
+    },
+    restrictions = { -- A person must pass ALL the restriction checks. Remove an item below to automatically pass that check.
+        job = "any", -- Allowed job. Can be an array of strings for multiple jobs. Any for all jobs
+        gang = "any", -- Allowed gang. Can be an array of strings for multiple gangs. Any for all gangs
+        allowedClasses = {}, -- Array of allowed classes. Empty will allow any but denied classes.
+        deniedClasses = {}, -- Array of denied classes.
+    },
+    zones = {
+        { coords = vector3(-212.55, -1320.56, 31.0), length = 6.0, width = 4.0, heading = 270.0, minZ = 29.88, maxZ = 33.48 },
+        { coords = vector3(-222.47, -1329.73, 31.0), length = 6.0, width = 4.4, heading = 270.0, minZ = 29.88, maxZ = 33.48 },
+    }
+},
+
+Vehicle Classes:  
+0: Compacts     1: Sedans       2: SUVs         3: Coupes       4: Muscle       5: Sports Classics  
+6: Sports       7: Super        8: Motorcycles  9: Off-road     10: Industrial  11: Utility  
+12: Vans        13: Cycles      14: Boats       15: Helicopters 16: Planes      17: Service  
+18: Emergency   19: Military    20: Commercial  21: Trains  
+ ]]
+
+Config = Config or {}
+
+Config.Locations = {
+    ['Innocence'] = {
+        settings = {
+            label = 'Bennys Motorworks',
+            welcomeLabel = "Welcome to Benny's Motorworks!",
+            enabled = true,
+        },
+        blip = {
+            label = 'Bennys Motorworks',
+            coords = vector3(-205.6992, -1312.7377, 31.1588), 
+            sprite = 72,
+            scale = 0.65,
+            color = 0,
+            display = 4,
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            wheels = true, 
+            tint = true, 
+            plate = true, 
+            extras = true, 
+            neons = true, 
+            xenons = true, 
+            horn = true,
+        },
+        drawtextui = { 
+            text = "Bennys Motorworks"
+        },
+        restrictions = { deniedClasses = { 18 } },
+        zones = {
+            { coords = vector3(-212.55, -1320.56, 31.0), length = 6.0, width = 4.0, heading = 270.0, minZ = 29.88, maxZ = 33.48 },
+            { coords = vector3(-222.47, -1329.73, 31.0), length = 6.0, width = 4.0, heading = 270.0, minZ = 29.88, maxZ = 33.48 },
+        }
+    },
+
+    ['Power'] = {
+        settings = {
+            label = 'Bennys Motorworks',
+            welcomeLabel = "Welcome to Benny's Motorworks!",
+            enabled = true,
+        },
+        blip = {
+            label = 'Bennys Motorworks',
+            coords = vector3(-41.8942, -1044.1943, 28.6297), 
+            sprite = 72,
+            scale = 0.65,
+            color = 0,
+            display = 4,
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            wheels = true, 
+            tint = true, 
+            plate = true, 
+            extras = true, 
+            neons = true, 
+            xenons = true, 
+            horn = true,
+        },
+        drawtextui = { 
+            text = "Bennys Motorworks"
+        },
+        restrictions = { deniedClasses = { 18 } },
+        zones = {
+            { coords = vector3(-32.48, -1065.38, 28.4), length = 6.0, width = 4.0, heading = 340.0, minZ = 27.0, maxZ = 31.0 },
+            { coords = vector3(-38.12, -1052.85, 28.4), length = 6.0, width = 4.0, heading = 340.0, minZ = 27.0, maxZ = 31.0 },
+        }
+    },
+
+    ['Popular'] = {
+        settings = {
+            label = 'Customs Motorworks',
+            welcomeLabel = "Welcome to Customs Motorworks!",
+            enabled = true,
+        },
+        blip = {
+            label = 'Bennys Motorworks',
+            coords = vector3(725.8828, -1088.7747, 22.1693), 
+            sprite = 72,
+            scale = 0.65,
+            color = 0,
+            display = 4,
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            wheels = true, 
+            tint = true, 
+            plate = true, 
+            extras = true, 
+            neons = true, 
+            xenons = true, 
+            horn = true,
+        },
+        drawtextui = { 
+            text = "Customs Motorworks"
+        },
+        restrictions = { deniedClasses = { 18 } },
+        zones = {
+            { coords = vector3(732.99, -1075.0, 22.17), length = 6.0, width = 4.0, heading = 180.0, minZ = 21.0, maxZ = 25.0 },
+            { coords = vector3(731.47, -1088.91, 22.17), length = 6.0, width = 4.0, heading = 90.0, minZ = 21.0, maxZ = 25.0 },
+        }
+    },
+
+    ['Harmony'] = {
+        settings = {
+            label = 'Harmony Motorworks',
+            welcomeLabel = "Welcome to Harmony Motorworks!",
+            enabled = true,
+        },
+        blip = {
+            label = 'Bennys Motorworks',
+            coords = vector3(1178.3921, 2640.5449, 37.7539), 
+            sprite = 72,
+            scale = 0.65,
+            color = 0,
+            display = 4,
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            wheels = true, 
+            tint = true, 
+            plate = true, 
+            extras = true, 
+            neons = true, 
+            xenons = true, 
+            horn = true,
+        },
+        drawtextui = { 
+            text = "Harmony Motorworks"
+        },
+        restrictions = { deniedClasses = { 18 } },
+        zones = {
+            { coords = vector3(1182.11, 2640.3, 37.75), length = 6.0, width = 4.0, heading = 0.0, minZ = 36.0, maxZ = 40.0 },
+            { coords = vector3(1174.78, 2640.17, 37.75), length = 6.0, width = 4.0, heading = 0.0, minZ = 36.0, maxZ = 40.0 },
+        }
+    },
+
+    ['Hayes'] = {
+        settings = {
+            label = 'Hayes Motorworks',
+            welcomeLabel = "Welcome to Hayes Motorworks!",
+            enabled = true,
+        },
+        blip = {
+            label = 'Bennys Motorworks',
+            coords = vector3(-1420.1882, -441.8745, 35.9097), 
+            sprite = 72,
+            scale = 0.65,
+            color = 0,
+            display = 4,
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            wheels = true, 
+            tint = true, 
+            plate = true, 
+            extras = true, 
+            neons = true, 
+            xenons = true, 
+            horn = true,
+        },
+        drawtextui = { 
+            text = "Hayes Motorworks"
+        },
+        restrictions = { deniedClasses = { 18 } },
+        zones = {
+            { coords = vector3(-1417.12, -445.98, 35.91), length = 6.0, width = 4.0, heading = 32.0, minZ = 35.0, maxZ = 39.0 },
+            { coords = vector3(-1423.67, -450.03, 35.91), length = 6.0, width = 4.0, heading = 32.0, minZ = 35.0, maxZ = 39.0 },
+        }
+    },
+
+    ['Paleto'] = {
+        settings = {
+            label = 'Billys Motorworks',
+            welcomeLabel = "Welcome to Billys Motorworks!",
+            enabled = true,
+        },
+        blip = {
+            label = 'Bennys Motorworks',
+            coords = vector3(108.3242, 6624.0996, 31.7873), 
+            sprite = 72,
+            scale = 0.65,
+            color = 0,
+            display = 4,
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            wheels = true, 
+            tint = true, 
+            plate = true, 
+            extras = true, 
+            neons = true, 
+            xenons = true, 
+            horn = true,
+        },
+        drawtextui = { 
+            text = "Billys Motorworks"
+        },
+        restrictions = { deniedClasses = { 18 } },
+        zones = {
+            { coords = vector3(110.93, 6626.51, 31.79), length = 6.0, width = 4.0, heading = 225.0, minZ = 30.5, maxZ = 34.5 },
+            { coords = vector3(105.8, 6621.43, 31.79), length = 6.0, width = 4.0, heading = 225.0, minZ = 30.5, maxZ = 34.5 },
+        }
+    },
+
+    ['Tunershop'] = {
+        settings = {
+            label = 'Tunershop',
+            welcomeLabel = "Welcome to the Tunershop!",
+            enabled = true,
+        },
+        blip = {
+            label = 'Tunershop',
+            coords = vector3(140.6093, -3030.3933, 7.0409), 
+            sprite = 446,
+            scale = 0.65,
+            color = 0,
+            display = 4,
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            wheels = true, 
+            tint = true, 
+            plate = true, 
+            extras = true, 
+            neons = true, 
+            xenons = true, 
+            horn = true,
+        },
+        drawtextui = { 
+            text = "Tunershop",
+            icon = "material-icons",
+            materialIcon = 'construction', 
+        },
+        restrictions = { deniedClasses = { 18 } },
+        zones = {
+            { coords = vector3(144.96, -3030.46, 7.06), length = 6.0, width = 4.0, heading = 180.0, minZ = 6.0, maxZ = 10.0 },
+            { coords = vector3(135.92, -3030.5, 7.04), length = 6.0, width = 4.0, heading = 180.0, minZ = 6.0, maxZ = 10.0 },
+        }
+    },
+
+    ['MRPD'] = {
+        settings = {
+            label = 'MRPD Motorworks',
+            welcomeLabel = "Welcome to MRPD Motorworks!",
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            tint = true, 
+            extras = true,
+        },
+        drawtextui = { 
+            text = "MRPD Motorworks",
+        },
+        restrictions = {
+            job = { 'police', 'bcso', 'sasp' },
+            allowedClasses = { 18 },
+        },
+        zones = {
+            { coords = vector3(450.09, -975.92, 25.7), length = 9.0, width = 4.0, heading = 90.0, minZ = 24.5, maxZ = 28.5 },
+            { coords = vector3(435.53, -975.97, 25.7), length = 9.0, width = 4.0, heading = 90.0, minZ = 24.5, maxZ = 28.5 },
+        }
+    },
+
+    ['Pillbox'] = {
+        settings = {
+            label = 'Pillbox Motorworks',
+            welcomeLabel = "Welcome to Pillbox Motorworks!",
+            enabled = true,
+        },
+        categories = {
+            repair = true, 
+            respray = true, 
+            liveries = true,
+            tint = true, 
+            extras = true,
+        },
+        drawtextui = { 
+            text = "Pillbox Motorworks"
+        },
+        restrictions = {
+            job = { 'ambulance' },
+            allowedClasses = { 18 },
+        },
+        zones = {
+            { coords = vector3(337.2, -579.6, 28.8), length = 9.4, width = 4.2, heading = 340.0, minZ = 27.5, maxZ = 31.5 },
+            { coords = vector3(340.38, -570.8, 28.8), length = 8.8, width = 4.2, heading = 340.0, minZ = 27.5, maxZ = 31.5 },
+        }
+    },
+}

--- a/shared/locations.lua
+++ b/shared/locations.lua
@@ -1,4 +1,4 @@
---[[ 
+--[[
     ['Innocence'] = {
     settings = {
         label = 'Bennys Motorworks', -- Text label for anything that wants it
@@ -7,7 +7,7 @@
     },
     blip = {
         label = 'Bennys Motorworks',
-        coords = vector3(-205.6992, -1312.7377, 31.1588), 
+        coords = vector3(-205.6992, -1312.7377, 31.1588),
         sprite = 72,
         scale = 0.65,
         color = 0,
@@ -15,18 +15,18 @@
         enabled = true,
     },
     categories = { -- Only include the categories you want. A category not listed defaults to FALSE.
-        repair = true, 
-        mods = true, 
+        repair = true,
+        mods = true,
         armor = true,
-        respray = true, 
+        respray = true,
         liveries = true,
-        wheels = true, 
-        tint = true, 
-        plate = true, 
-        extras = true, 
-        neons = true, 
-        xenons = true, 
-        horn = true, 
+        wheels = true,
+        tint = true,
+        plate = true,
+        extras = true,
+        neons = true,
+        xenons = true,
+        horn = true,
         turbo = true,
     },
     drawtextui = { -- background1 and background2 are also valid options for the background gradiant
@@ -44,11 +44,11 @@
     }
 },
 
-Vehicle Classes:  
-0: Compacts     1: Sedans       2: SUVs         3: Coupes       4: Muscle       5: Sports Classics  
-6: Sports       7: Super        8: Motorcycles  9: Off-road     10: Industrial  11: Utility  
-12: Vans        13: Cycles      14: Boats       15: Helicopters 16: Planes      17: Service  
-18: Emergency   19: Military    20: Commercial  21: Trains  
+Vehicle Classes:
+0: Compacts     1: Sedans       2: SUVs         3: Coupes       4: Muscle       5: Sports Classics
+6: Sports       7: Super        8: Motorcycles  9: Off-road     10: Industrial  11: Utility
+12: Vans        13: Cycles      14: Boats       15: Helicopters 16: Planes      17: Service
+18: Emergency   19: Military    20: Commercial  21: Trains
  ]]
 
 Config = Config or {}
@@ -62,7 +62,7 @@ Config.Locations = {
         },
         blip = {
             label = 'Bennys Motorworks',
-            coords = vector3(-205.6992, -1312.7377, 31.1588), 
+            coords = vector3(-205.6992, -1312.7377, 31.1588),
             sprite = 72,
             scale = 0.65,
             color = 0,
@@ -70,18 +70,18 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            wheels = true, 
-            tint = true, 
-            plate = true, 
-            extras = true, 
-            neons = true, 
-            xenons = true, 
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
             horn = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Bennys Motorworks"
         },
         restrictions = { deniedClasses = { 18 } },
@@ -99,7 +99,7 @@ Config.Locations = {
         },
         blip = {
             label = 'Bennys Motorworks',
-            coords = vector3(-41.8942, -1044.1943, 28.6297), 
+            coords = vector3(-41.8942, -1044.1943, 28.6297),
             sprite = 72,
             scale = 0.65,
             color = 0,
@@ -107,18 +107,18 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            wheels = true, 
-            tint = true, 
-            plate = true, 
-            extras = true, 
-            neons = true, 
-            xenons = true, 
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
             horn = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Bennys Motorworks"
         },
         restrictions = { deniedClasses = { 18 } },
@@ -136,7 +136,7 @@ Config.Locations = {
         },
         blip = {
             label = 'Bennys Motorworks',
-            coords = vector3(725.8828, -1088.7747, 22.1693), 
+            coords = vector3(725.8828, -1088.7747, 22.1693),
             sprite = 72,
             scale = 0.65,
             color = 0,
@@ -144,18 +144,18 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            wheels = true, 
-            tint = true, 
-            plate = true, 
-            extras = true, 
-            neons = true, 
-            xenons = true, 
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
             horn = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Customs Motorworks"
         },
         restrictions = { deniedClasses = { 18 } },
@@ -173,7 +173,7 @@ Config.Locations = {
         },
         blip = {
             label = 'Bennys Motorworks',
-            coords = vector3(1178.3921, 2640.5449, 37.7539), 
+            coords = vector3(1178.3921, 2640.5449, 37.7539),
             sprite = 72,
             scale = 0.65,
             color = 0,
@@ -181,18 +181,18 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            wheels = true, 
-            tint = true, 
-            plate = true, 
-            extras = true, 
-            neons = true, 
-            xenons = true, 
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
             horn = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Harmony Motorworks"
         },
         restrictions = { deniedClasses = { 18 } },
@@ -210,7 +210,7 @@ Config.Locations = {
         },
         blip = {
             label = 'Bennys Motorworks',
-            coords = vector3(-1420.1882, -441.8745, 35.9097), 
+            coords = vector3(-1420.1882, -441.8745, 35.9097),
             sprite = 72,
             scale = 0.65,
             color = 0,
@@ -218,18 +218,18 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            wheels = true, 
-            tint = true, 
-            plate = true, 
-            extras = true, 
-            neons = true, 
-            xenons = true, 
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
             horn = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Hayes Motorworks"
         },
         restrictions = { deniedClasses = { 18 } },
@@ -247,7 +247,7 @@ Config.Locations = {
         },
         blip = {
             label = 'Bennys Motorworks',
-            coords = vector3(108.3242, 6624.0996, 31.7873), 
+            coords = vector3(108.3242, 6624.0996, 31.7873),
             sprite = 72,
             scale = 0.65,
             color = 0,
@@ -255,18 +255,18 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            wheels = true, 
-            tint = true, 
-            plate = true, 
-            extras = true, 
-            neons = true, 
-            xenons = true, 
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
             horn = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Billys Motorworks"
         },
         restrictions = { deniedClasses = { 18 } },
@@ -284,7 +284,7 @@ Config.Locations = {
         },
         blip = {
             label = 'Tunershop',
-            coords = vector3(140.6093, -3030.3933, 7.0409), 
+            coords = vector3(140.6093, -3030.3933, 7.0409),
             sprite = 446,
             scale = 0.65,
             color = 0,
@@ -292,21 +292,21 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            wheels = true, 
-            tint = true, 
-            plate = true, 
-            extras = true, 
-            neons = true, 
-            xenons = true, 
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
             horn = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Tunershop",
             icon = "material-icons",
-            materialIcon = 'construction', 
+            materialIcon = 'construction',
         },
         restrictions = { deniedClasses = { 18 } },
         zones = {
@@ -322,13 +322,14 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            tint = true, 
+            tint = true,
             extras = true,
+            plate = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "MRPD Motorworks",
         },
         restrictions = {
@@ -348,13 +349,14 @@ Config.Locations = {
             enabled = true,
         },
         categories = {
-            repair = true, 
-            respray = true, 
+            repair = true,
+            respray = true,
             liveries = true,
-            tint = true, 
+            tint = true,
             extras = true,
+            plate = true,
         },
-        drawtextui = { 
+        drawtextui = {
             text = "Pillbox Motorworks"
         },
         restrictions = {


### PR DESCRIPTION
This update requires PR to radial menu here: https://github.com/qbcore-framework/qb-radialmenu/pull/81
This update requires setText() support from the dev branch of QB-Core.

- Polyzone, radial menu, and drawtext support for entering customs locations
- Locations config supports customizing each location drastically, a well as having unlimited zones created under that location. (Options can be found in the locations.lua)
- Config option for money types being used for repairs/changes
- Ability to dynamically update any of the settings (such as enabled/disabled) to all clients, saved serverside and networked on change.
- Fixed some bugs causing errors in the UI ;)
- Support for originalXenon and originalTurbo state
- Renamed events to fit proper naming scheme (they are not called anywhere else)
- Fixes tires on repair
- Old liveries menu won't even show if theres nothing to populate
- Removed legacy code for not allowing emergency vehicles to populate certain menus. Code was half finished, and did not stop the main menu from populating, causing errors when selected and nothing populating in the sub menu
- Setting maxVehiclePerformanceUpgrades to -1 removes all performance upgrades from the shop
- More wheel options from Sonny-BEE
- Some other stuff I probably forgot