### PR TITLE
Fix horns not displaying in menu

### DIFF
--- a/client/cl_ui.lua
+++ b/client/cl_ui.lua
@@ -233,7 +233,7 @@ function InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
                     populateMenu("mainMenu", v.id, v.category, "none")
                 end
             elseif v.id == 14 then
-                if categories.horns then
+                if categories.horn then
                     populateMenu("mainMenu", v.id, v.category, "none")
                 end
             elseif v.id == 18 then


### PR DESCRIPTION
When populating garage menu, the table name in the list "categories" is "horn" singular and not "horns". This resulted in the option to customize car horns to not display in the menu.