### PR TITLE
Fix error when using Enterlocation from other script

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -765,7 +765,7 @@ function EnterLocation(override)
         return
     end
 
-    if Config.UseRadial then
+    if Config.UseRadial and not override then
         exports['qb-radialmenu']:RemoveOption(radialMenuItemId)
         radialMenuItemId = nil
     end


### PR DESCRIPTION
When using an admin menu that allows the admin to enter bennys anywhere (for testing purposes) there is an error when calling the Enterlocation function.

By adding check on override on the radial remove export this error is prevented (there is no radial menu added outside of a poly) AND normal working is not interferred with.

admin menu used: dc-adminmenu
