### PR TITLE
Add option to disable customs when enough mechanics are available

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -900,23 +900,30 @@ function CheckRestrictions(location)
 end
 
 function SetupInteraction()
-    local text = CustomsData.drawtextui
-    if Config.UseRadial then
-        if not radialMenuItemId then
-            radialMenuItemId = exports['qb-radialmenu']:AddOption({
-                id = 'customs',
-                title = 'Enter Customs',
-                icon = 'wrench',
-                type = 'client',
-                event = 'qb-customs:client:EnterCustoms',
-                shouldClose = true
-            })
+    QBCore.Functions.TriggerCallback('getCurrentMechanics', function(result)
+        local text = CustomsData.drawtextui
+        local currentMechanics = result
+        if Config.DisableWhenMechanicsOnline and currentMechanics >= Config.MinOnlineMechanics then
+            text = 'Customs is currrently disabled because you can go to a mechanic'
+        else
+            if Config.UseRadial then
+                if not radialMenuItemId then
+                    radialMenuItemId = exports['qb-radialmenu']:AddOption({
+                        id = 'customs',
+                        title = 'Enter Customs',
+                        icon = 'wrench',
+                        type = 'client',
+                        event = 'qb-customs:client:EnterCustoms',
+                        shouldClose = true
+                    })
+                end
+            else
+                text = '[E] '..text
+                CheckForKeypress()
+            end
         end
-    else
-        text = '[E] '..text
-        CheckForKeypress()
-    end
-    exports['qb-core']:DrawText(text, 'left')
+        exports['qb-core']:DrawText(text, 'left')
+    end)
 end
 
 exports('GetCustomsData', function() if next(CustomsData) ~= nil then return CustomsData else return nil end end)

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -904,7 +904,7 @@ function SetupInteraction()
         local text = CustomsData.drawtextui
         local currentMechanics = result
         if Config.DisableWhenMechanicsOnline and currentMechanics >= Config.MinOnlineMechanics then
-            text = 'Customs is currrently disabled because you can go to a mechanic'
+            text = 'Customs are currrently disabled because you can go to a mechanic'
         else
             if Config.UseRadial then
                 if not radialMenuItemId then

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -904,7 +904,7 @@ function SetupInteraction()
         local text = CustomsData.drawtextui
         local currentMechanics = result
         if Config.DisableWhenMechanicsOnline and currentMechanics >= Config.MinOnlineMechanics then
-            text = 'Customs are currrently disabled because you can go to a mechanic'
+            text = text .. ' is currently unavailable. Please find a mechanic.'
         else
             if Config.UseRadial then
                 if not radialMenuItemId then

--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,10 @@ Config.MoneyType = 'bank'
 Config.RepairMoneyType = 'cash'
 Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
+
+Config.DisableWhenMechanicsOnline = false -- Disables customs if enough mechanics are online
+Config.MinOnlineMechanics = 1 -- How many mechanics have to be online to disable customs
+
 maxVehiclePerformanceUpgrades = 0 -- | All Upgrades: 0 | No Upgrades: -1 | Can be -1 to 4
 
 -- ADJUST PRICING

--- a/config.lua
+++ b/config.lua
@@ -6,8 +6,8 @@ Config.RepairMoneyType = 'cash'
 Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 
-Config.DisableWhenMechanicsOnline = false -- Disables customs if enough mechanics are online
-Config.MinOnlineMechanics = 1 -- How many mechanics have to be online to disable customs
+Config.DisableWhenMechanicsOnline = false -- Disables customs if enough mechanics are online and on-duty
+Config.MinOnlineMechanics = 1 -- How many mechanics have to be online and on-duty to disable customs
 
 maxVehiclePerformanceUpgrades = 0 -- | All Upgrades: 0 | No Upgrades: -1 | Can be -1 to 4
 

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -23,7 +23,7 @@ QBCore.Functions.CreateCallback('getCurrentMechanics', function(_, cb)
     local currentMechanics = 0
     local players = QBCore.Functions.GetQBPlayers()
     for i = 1, #players do
-        if players[i].PlayerData.job.name == 'mechanic' then
+        if players[i].PlayerData.job.name == 'mechanic' and players[i].PlayerData.job.onduty then
             currentMechanics += 1
         end
     end

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -16,8 +16,19 @@ local function IsVehicleOwned(plate)
 end
 
 -----------------------
-----   Threads     ----
+----   Callbacks   ----
 -----------------------
+
+QBCore.Functions.CreateCallback('getCurrentMechanics', function(_, cb)
+    local currentMechanics = 0
+    local players = QBCore.Functions.GetQBPlayers()
+    for i = 1, #players do
+        if players[i].PlayerData.job.name == 'mechanic' then
+            currentMechanics += 1
+        end
+    end
+    cb(currentMechanics)
+end)
 
 -----------------------
 ---- Server Events ----


### PR DESCRIPTION
**Describe Pull request**
Adds an option to disable customs when enough mechanics are online, and on-duty.

This adds an option in the config to enable/disable this functionality, and an option for setting the minimum amount of required on-duty mechanics to disable customs.

This also adds a server callback to check the current amount of on-duty mechanics.

When this functionality is enabled and enough mechanics are online and on-duty, the message on the left will say that customs are disabled and the player should go to a mechanic.

Closes #125
Closes #131

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
