### PR TITLE
Allow mechanics to use customs when disabled in favor of mechanics

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -901,7 +901,7 @@ function SetupInteraction()
     QBCore.Functions.TriggerCallback('getCurrentMechanics', function(result)
         local text = CustomsData.drawtextui
         local currentMechanics = result
-        if Config.DisableWhenMechanicsOnline and currentMechanics >= Config.MinOnlineMechanics then
+        if PlayerData.job.name ~= 'mechanic' and Config.DisableWhenMechanicsOnline and currentMechanics >= Config.MinOnlineMechanics then
             text = text .. ' is currently unavailable. Please find a mechanic.'
         else
             if Config.UseRadial then


### PR DESCRIPTION
**Describe Pull request**
Allows mechanics to use all customs when they are disabled due to mechanics being online and on-duty

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
