### PR TITLE
Add option for using society money

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -109,7 +109,7 @@ function AttemptPurchase(type, upgradeLevel)
     if upgradeLevel ~= nil then
         upgradeLevel = upgradeLevel + 2
     end
-    TriggerServerEvent("qb-customs:server:attemptPurchase", type, upgradeLevel)
+    TriggerServerEvent("qb-customs:server:attemptPurchase", type, upgradeLevel, CustomsData.location)
 
     attemptingPurchase = true
 

--- a/config.lua
+++ b/config.lua
@@ -28,6 +28,10 @@ Config.DisabledCategoriesMechanics = {
     cosmetics = false,
 } -- `true` to disable category if enough mechanics are online and on-duty, `false` to ignore
 
+Config.PaidBySociety = {
+    -- 'mechanic',
+} -- List of job societies that pay for employees, regardless of the customs location
+
 maxVehiclePerformanceUpgrades = 0 -- | All Upgrades: 0 | No Upgrades: -1 | Can be -1 to 4
 
 -- ADJUST PRICING

--- a/config.lua
+++ b/config.lua
@@ -28,6 +28,7 @@ Config.DisabledCategoriesMechanics = {
     cosmetics = false,
 } -- `true` to disable category if enough mechanics are online and on-duty, `false` to ignore
 
+Config.PayWithSocietyWhenJobRestricted = true -- Whether to have job societies pay for employees if the location is restricted to the job
 Config.PaidBySociety = {
     -- 'mechanic',
 } -- List of job societies that pay for employees, regardless of the customs location

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -32,7 +32,7 @@ AddEventHandler("playerDropped", function()
     RepairCosts[source] = nil
 end)
 
-RegisterNetEvent('qb-customs:server:attemptPurchase', function(type, upgradeLevel)
+RegisterNetEvent('qb-customs:server:attemptPurchase', function(type, upgradeLevel, location)
     local source = source
     local Player = QBCore.Functions.GetPlayer(source)
     local job = Player.PlayerData.job.name
@@ -48,16 +48,27 @@ RegisterNetEvent('qb-customs:server:attemptPurchase', function(type, upgradeLeve
     else
         price = vehicleCustomisationPrices[type].price
     end
+    local restrictionJobs = Config.Locations[location] and (Config.Locations[location].restrictions and Config.Locations[location].restrictions.job) or {}
+    local payWithSociety = false
+    for i = 1, #restrictionJobs do
+        if restrictionJobs[i] == job then
+            payWithSociety = true
+            break
+        end
+    end
     for i = 1, #Config.PaidBySociety do
         if Config.PaidBySociety[i] == job then
-            local societyBalance = exports['qb-management']:GetAccount(job)
-            if societyBalance >= price then
-                balance = societyBalance
-                moneyType = 'society'
-            else
-                TriggerClientEvent('QBCore:Notify', source, "Your job society can't pay for this. You will be charged instead.")
-            end
+            payWithSociety = true
             break
+        end
+    end
+    if payWithSociety then
+        local societyBalance = exports['qb-management']:GetAccount(job)
+        if societyBalance >= price then
+            balance = societyBalance
+            moneyType = 'society'
+        else
+            TriggerClientEvent('QBCore:Notify', source, "Your job society can't pay for this. You will be charged instead.")
         end
     end
     if balance >= price then

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -48,7 +48,7 @@ RegisterNetEvent('qb-customs:server:attemptPurchase', function(type, upgradeLeve
     else
         price = vehicleCustomisationPrices[type].price
     end
-    local restrictionJobs = Config.Locations[location] and (Config.Locations[location].restrictions and Config.Locations[location].restrictions.job) or {}
+    local restrictionJobs = Config.Locations[location] and Config.Locations[location].restrictions.job or {}
     local payWithSociety = false
     for i = 1, #restrictionJobs do
         if restrictionJobs[i] == job then

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -37,34 +37,22 @@ RegisterNetEvent('qb-customs:server:attemptPurchase', function(type, upgradeLeve
     local Player = QBCore.Functions.GetPlayer(source)
     local moneyType = Config.MoneyType
     local balance = Player.Functions.GetMoney(moneyType)
-
+    local price
     if type == "repair" then
-        local repairCost = RepairCosts[source] or Config.DefaultRepairPrice
+        price = RepairCosts[source] or Config.DefaultRepairPrice
         moneyType = Config.RepairMoneyType
         balance = Player.Functions.GetMoney(moneyType)
-        if balance >= repairCost then
-            Player.Functions.RemoveMoney(moneyType, repairCost, "bennys")
-            TriggerClientEvent('qb-customs:client:purchaseSuccessful', source)
-            exports['qb-management']:AddMoney("mechanic", repairCost)
-        else
-            TriggerClientEvent('qb-customs:client:purchaseFailed', source)
-        end
     elseif type == "performance" or type == "turbo" then
-        if balance >= vehicleCustomisationPrices[type].prices[upgradeLevel] then
-            TriggerClientEvent('qb-customs:client:purchaseSuccessful', source)
-            Player.Functions.RemoveMoney(moneyType, vehicleCustomisationPrices[type].prices[upgradeLevel], "bennys")
-            exports['qb-management']:AddMoney("mechanic", vehicleCustomisationPrices[type].prices[upgradeLevel])
-        else
-            TriggerClientEvent('qb-customs:client:purchaseFailed', source)
-        end
+        price = vehicleCustomisationPrices[type].prices[upgradeLevel]
     else
-        if balance >= vehicleCustomisationPrices[type].price then
-            TriggerClientEvent('qb-customs:client:purchaseSuccessful', source)
-            Player.Functions.RemoveMoney(moneyType, vehicleCustomisationPrices[type].price, "bennys")
-            exports['qb-management']:AddMoney("mechanic", vehicleCustomisationPrices[type].price)
-        else
-            TriggerClientEvent('qb-customs:client:purchaseFailed', source)
-        end
+        price = vehicleCustomisationPrices[type].price
+    end
+    if balance >= price then
+        Player.Functions.RemoveMoney(moneyType, price, "bennys")
+        TriggerClientEvent('qb-customs:client:purchaseSuccessful', source)
+        exports['qb-management']:AddMoney("mechanic", price)
+    else
+        TriggerClientEvent('qb-customs:client:purchaseFailed', source)
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
This adds:
1. An option for job societies to pay for their employees when in a customs location that is restricted to that same job
2. An option for certain job societies to always pay for their employees regardless of the location

If the society does not have enough money then the employee gets charged instead.

Resolves #86
Fixes #130
Resolves #135

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**