### PR TITLE
Improve callback name

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -898,7 +898,7 @@ function CheckRestrictions(location)
 end
 
 function SetupInteraction()
-    QBCore.Functions.TriggerCallback('getCurrentMechanics', function(result)
+    QBCore.Functions.TriggerCallback('customs:getOnDutyMechanics', function(result)
         local text = CustomsData.drawtextui
         local currentMechanics = result
         if PlayerData.job.name ~= 'mechanic' and Config.DisableWhenMechanicsOnline and currentMechanics >= Config.MinOnlineMechanics then

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -898,7 +898,7 @@ function CheckRestrictions(location)
 end
 
 function SetupInteraction()
-    QBCore.Functions.TriggerCallback('customs:getOnDutyMechanics', function(result)
+    QBCore.Functions.TriggerCallback('qb-customs:server:getOnDutyMechanics', function(result)
         local text = CustomsData.drawtextui
         local currentMechanics = result
         if PlayerData.job.name ~= 'mechanic' and Config.DisableWhenMechanicsOnline and currentMechanics >= Config.MinOnlineMechanics then

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -19,7 +19,7 @@ end
 ----   Callbacks   ----
 -----------------------
 
-QBCore.Functions.CreateCallback('getCurrentMechanics', function(_, cb)
+QBCore.Functions.CreateCallback('customs:getOnDutyMechanics', function(_, cb)
     local currentMechanics = 0
     local players = QBCore.Functions.GetQBPlayers()
     for i = 1, #players do

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -19,7 +19,7 @@ end
 ----   Callbacks   ----
 -----------------------
 
-QBCore.Functions.CreateCallback('customs:getOnDutyMechanics', function(_, cb)
+QBCore.Functions.CreateCallback('qb-customs:server:getOnDutyMechanics', function(_, cb)
     local currentMechanics = 0
     local players = QBCore.Functions.GetQBPlayers()
     for i = 1, #players do


### PR DESCRIPTION
**Describe Pull request**
Renames `getCurrentMechanics` to `qb-customs:server:getOnDutyMechanics` to avoid conflicts and improve readability in case another resource decides to use it.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **no**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
