### PR TITLE
Add a permission check in exploitable event

### DIFF
--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -87,7 +87,7 @@ RegisterNetEvent("qb-customs:server:updateVehicle", function(myCar)
     end
 end)
 
--- Use somthing like this to dynamically enable/disable a location. Can be used to change anything at a location.
+-- Use this event to dynamically enable/disable a location. Can be used to change anything at a location.
 -- TriggerEvent('qb-customs:server:UpdateLocation', 'Hayes', 'settings', 'enabled', test)
 
 RegisterNetEvent('qb-customs:server:UpdateLocation', function(location, type, key, value)

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -81,7 +81,6 @@ end)
 
 RegisterNetEvent('qb-customs:server:updateRepairCost', function(cost)
     local source = source
-    if not QBCore.Functions.HasPermission(source, 'god') then return CancelEvent() end
     RepairCosts[source] = cost
 end)
 

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -77,6 +77,7 @@ end)
 
 RegisterNetEvent('qb-customs:server:updateRepairCost', function(cost)
     local source = source
+    if not QBCore.Functions.HasPermission(source, 'god') then CancelEvent() end
     RepairCosts[source] = cost
 end)
 
@@ -90,6 +91,8 @@ end)
 -- TriggerEvent('qb-customs:server:UpdateLocation', 'Hayes', 'settings', 'enabled', test)
 
 RegisterNetEvent('qb-customs:server:UpdateLocation', function(location, type, key, value)
+    local source = source
+    if not QBCore.Functions.HasPermission(source, 'god') then CancelEvent() end
     Config.Locations[location][type][key] = value
     TriggerClientEvent('qb-customs:client:UpdateLocation', -1, location, type, key, value)
 end)

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -81,7 +81,7 @@ end)
 
 RegisterNetEvent('qb-customs:server:updateRepairCost', function(cost)
     local source = source
-    if not QBCore.Functions.HasPermission(source, 'god') then CancelEvent() end
+    if not QBCore.Functions.HasPermission(source, 'god') then return CancelEvent() end
     RepairCosts[source] = cost
 end)
 
@@ -96,7 +96,7 @@ end)
 
 RegisterNetEvent('qb-customs:server:UpdateLocation', function(location, type, key, value)
     local source = source
-    if not QBCore.Functions.HasPermission(source, 'god') then CancelEvent() end
+    if not QBCore.Functions.HasPermission(source, 'god') then return CancelEvent() end
     Config.Locations[location][type][key] = value
     TriggerClientEvent('qb-customs:client:UpdateLocation', -1, location, type, key, value)
 end)

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -30,6 +30,10 @@ QBCore.Functions.CreateCallback('qb-customs:server:getOnDutyMechanics', function
     cb(currentMechanics)
 end)
 
+QBCore.Functions.CreateCallback('qb-customs:server:GetLocations', function(_, cb)
+    cb(Config.Locations)
+end)
+
 -----------------------
 ---- Server Events ----
 -----------------------
@@ -95,10 +99,6 @@ RegisterNetEvent('qb-customs:server:UpdateLocation', function(location, type, ke
     if not QBCore.Functions.HasPermission(source, 'god') then CancelEvent() end
     Config.Locations[location][type][key] = value
     TriggerClientEvent('qb-customs:client:UpdateLocation', -1, location, type, key, value)
-end)
-
-QBCore.Functions.CreateCallback('qb-customs:server:GetLocations', function(_, cb)
-    cb(Config.Locations)
 end)
 
 -- name, help, args, argsrequired, cb, perms


### PR DESCRIPTION
**Describe Pull request**
This adds a permission check when trying to update a location.
This also fixes a comment typo and moves the `GetLocations` callback to the callbacks section.

I have currently only done so for the event that doesn't require much work (only 1-2 liners).

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **no**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
