### PR TITLE
Fix error when radial menu is enabled and customs is disabled

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -957,7 +957,7 @@ CreateThread(function()
                     CheckForGhostVehicle()
                 elseif CustomsData['location'] == location and CustomsData['spot'] == _name then
                     CustomsData = {}
-                    if Config.UseRadial then
+                    if Config.UseRadial and radialMenuItemId then
                         exports['qb-radialmenu']:RemoveOption(radialMenuItemId)
                         radialMenuItemId = nil
                     end


### PR DESCRIPTION
**Describe Pull request**
Fixes an error that occurs when `Config.UseRadial` is enabled and customs is disabled due to mechanics being on duty.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
