### PR TITLE
Fix stock liveries not being applied correctly

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -546,6 +546,10 @@ function ApplyMod(categoryID, modID)
         originalMod = modID
 
         SetVehicleMod(plyVeh, categoryID, modID)
+		
+	if categoryID == 48 then
+            SetVehicleLivery(plyVeh, modID)
+        end
     end
 end
 

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -546,8 +546,8 @@ function ApplyMod(categoryID, modID)
         originalMod = modID
 
         SetVehicleMod(plyVeh, categoryID, modID)
-		
-	if categoryID == 48 then
+
+        if categoryID == 48 then
             SetVehicleLivery(plyVeh, modID)
         end
     end


### PR DESCRIPTION
**Describe Pull request**
Fixes a bug where when a stock livery was bought in customs after buying a custom livery, it wouldn't be saved correctly in garages, which would apply the old custom livery to the vehicle.

PR #128 should've fixed the issue, but it has problems with indentation and it seems like the author abandoned it, so I applied the commit from the PR here and fixed it.

Fixes qbcore-framework/qb-core#572

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
