### PR TITLE
 Add `/customs` admin command

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -764,7 +764,7 @@ function EnterLocation(override)
         return
     end
 
-    if Config.UseRadial then
+    if Config.UseRadial and radialMenuItemId then
         exports['qb-radialmenu']:RemoveOption(radialMenuItemId)
         radialMenuItemId = nil
     end

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -97,3 +97,28 @@ end)
 QBCore.Functions.CreateCallback('qb-customs:server:GetLocations', function(_, cb)
     cb(Config.Locations)
 end)
+
+-- name, help, args, argsrequired, cb, perms
+QBCore.Commands.Add('customs', 'Open customs (admin only)', {}, false, function(source)
+    local ped = GetPlayerPed(source)
+    TriggerClientEvent('qb-customs:client:EnterCustoms', source, {
+        coords = GetEntityCoords(ped),
+        heading = GetEntityHeading(ped),
+        categories = {
+            repair = true,
+            mods = true,
+            armor = true,
+            respray = true,
+            liveries = true,
+            wheels = true,
+            tint = true,
+            plate = true,
+            extras = true,
+            neons = true,
+            xenons = true,
+            horn = true,
+            turbo = true,
+            cosmetics = true,
+        }
+    })
+end, 'admin')


### PR DESCRIPTION
**Describe Pull request**
Adds a `/customs` command for admins to access customs from anywhere.
Also fixes `EnterLocation` error when trying to use with `Config.UseRadial` set to `true` and not being in a customs location.

Closes #126
Closes #132

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
