### PR TITLE
Add repair prices to the config

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -791,7 +791,7 @@ function EnterLocation(override)
     InitiateMenus(isMotorcycle, GetVehicleBodyHealth(plyVeh), categories, welcomeLabel)
 
     SetTimeout(100, function()
-        if GetVehicleBodyHealth(plyVeh) < 1000.0 and categories.repair then
+        if (Config.BaseRepairPrice + 1000 - GetVehicleBodyHealth(plyVeh)) > 0 and categories.repair then
             DisplayMenu(true, "repairMenu")
         else
             DisplayMenu(true, "mainMenu")

--- a/client/cl_ui.lua
+++ b/client/cl_ui.lua
@@ -205,11 +205,12 @@ function InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
     --#[Repair Menu]#--
     if vehicleHealth < 1000.0 and categories.repair then
         local repairCost = math.ceil(Config.BaseRepairPrice + 1000 - vehicleHealth)
-
-        TriggerServerEvent("qb-customs:server:updateRepairCost", repairCost)
-        createMenu("repairMenu", welcomeLabel, "Repair Vehicle")
-        populateMenu("repairMenu", -1, "Repair", "$" .. repairCost)
-        finishPopulatingMenu("repairMenu")
+        if repairCost > 0 then
+            TriggerServerEvent("qb-customs:server:updateRepairCost", repairCost)
+            createMenu("repairMenu", welcomeLabel, "Repair Vehicle")
+            populateMenu("repairMenu", -1, "Repair", "$" .. repairCost)
+            finishPopulatingMenu("repairMenu")
+        end
     end
 
     --#[Main Menu]#--

--- a/client/cl_ui.lua
+++ b/client/cl_ui.lua
@@ -204,7 +204,7 @@ function InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
     local plyVeh = GetVehiclePedIsIn(plyPed, false)
     --#[Repair Menu]#--
     if vehicleHealth < 1000.0 and categories.repair then
-        local repairCost = math.ceil(1000 - vehicleHealth)
+        local repairCost = math.ceil(Config.BaseRepairPrice + 1000 - vehicleHealth)
 
         TriggerServerEvent("qb-customs:server:updateRepairCost", repairCost)
         createMenu("repairMenu", welcomeLabel, "Repair Vehicle")

--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,8 @@ Config = Config or {}
 Config.Debug = false -- Set to True to enable Debug Prints
 Config.MoneyType = 'bank'
 Config.RepairMoneyType = 'cash'
+Config.DefaultRepairPrice = 600 -- Repair price that is used if a vehicle-specific price is not available
+Config.BaseRepairPrice = 0 -- Starting repair price. Vehicle damage of each player (0-1000) is added to it later
 Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 

--- a/config.lua
+++ b/config.lua
@@ -4,7 +4,7 @@ Config.Debug = false -- Set to True to enable Debug Prints
 Config.MoneyType = 'bank'
 Config.RepairMoneyType = 'cash'
 Config.DefaultRepairPrice = 600 -- Repair price that is used if a vehicle-specific price is not available
-Config.BaseRepairPrice = 0 -- Starting repair price. Vehicle damage of each player (0-1000) is added to it later
+Config.BaseRepairPrice = 0 -- Starting repair price. Every player's vehicle damage (0-1000) is added to it later. If the final price is 0 or less, the repair menu does not appear
 Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 

--- a/server/sv_bennys.lua
+++ b/server/sv_bennys.lua
@@ -46,7 +46,7 @@ RegisterNetEvent('qb-customs:server:attemptPurchase', function(type, upgradeLeve
     local balance = Player.Functions.GetMoney(moneyType)
 
     if type == "repair" then
-        local repairCost = RepairCosts[source] or 600
+        local repairCost = RepairCosts[source] or Config.DefaultRepairPrice
         moneyType = Config.RepairMoneyType
         balance = Player.Functions.GetMoney(moneyType)
         if balance >= repairCost then


### PR DESCRIPTION
**Describe Pull request**
Previously repair prices were hardcoded, so I've added them to the config.
These are the 2 options added:
- `DefaultRepairPrice` (default: `600`) - Repair price that is used if a vehicle-specific price is not available (previously hardcoded as `600`)
- `BaseRepairPrice` (default: `0`) - Starting repair price. Every player's vehicle damage (0-1000) is added to it later. If the final price is 0 or less, the repair menu does not appear

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
