### PR TITLE
Add option to disable certain categories when mechanics are available

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -751,64 +751,74 @@ function EnterLocation(override)
         end
     elseif override then canEnter = true end
 
-    if Config.Debug then
-        print('***************************************************************************')
-        print(string.format('EnterLocation Debug Start | CanEnter: %s | Repair Only: %s | Override: %s', canEnter, repairOnly, json.encode(override)))
-        print('***************************************************************************')
-        if next(locationData) then for k, v in pairs(locationData) do print(k, json.encode(v)) end end
-        for k, v in pairs(categories) do print(k, v) end
-        print('***************************************************************************')
-        print('EnterLocation Debug End')
-        print('***************************************************************************')
-    end
-
-    if not canEnter then
-        QBCore.Functions.Notify('You cant do anything here!')
-        ExitBennys()
-        return
-    end
-
-    if Config.UseRadial and radialMenuItemId then
-        exports['qb-radialmenu']:RemoveOption(radialMenuItemId)
-        radialMenuItemId = nil
-    end
-
-    exports['qb-core']:HideText()
-
-    local plyPed = PlayerPedId()
-    local plyVeh = GetVehiclePedIsIn(plyPed, false)
-    local isMotorcycle
-
-    if GetVehicleClass(plyVeh) == 8 then --Motorcycle
-        isMotorcycle = true
-    else
-        isMotorcycle = false
-    end
-
-    SetVehicleModKit(plyVeh, 0)
-    SetEntityCoords(plyVeh, ((override and override.coords) or CustomsData.coords))
-    SetEntityHeading(plyVeh, ((override and override.heading) or CustomsData.heading))
-    FreezeEntityPosition(plyVeh, true)
-    SetEntityCollision(plyVeh, false, true)
-
-    local vehicleHealth = GetVehicleBodyHealth(plyVeh)
-
-    local welcomeLabel = (locationData and locationData.settings.welcomeLabel) or "Welcome to Benny's Motorworks!"
-    InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
-
-    SetTimeout(100, function()
-        if vehicleHealth < 1000.0 and (Config.BaseRepairPrice + 1000 - vehicleHealth) > 0 and categories.repair then
-            DisplayMenu(true, "repairMenu")
-        else
-            DisplayMenu(true, "mainMenu")
+    QBCore.Functions.TriggerCallback('qb-customs:server:getOnDutyMechanics', function(currentMechanics)
+        if currentMechanics >= Config.MinOnlineMechanics and not override and PlayerData.job.name ~= 'mechanic' then
+            repairOnly = true
+            for k, v in pairs(Config.DisabledCategoriesMechanics) do
+                if k ~= "repair" and not v and categories[k] then repairOnly = false end
+                if v then categories[k] = false end
+            end
+            QBCore.Functions.Notify('Some purchases are currently unavailable. Please find a mechanic.')
+        end
+        if Config.Debug then
+            print('***************************************************************************')
+            print(string.format('EnterLocation Debug Start | CanEnter: %s | Repair Only: %s | Override: %s', canEnter, repairOnly, json.encode(override)))
+            print('***************************************************************************')
+            if next(locationData) then for k, v in pairs(locationData) do print(k, json.encode(v)) end end
+            for k, v in pairs(categories) do print(k, v) end
+            print('***************************************************************************')
+            print('EnterLocation Debug End')
+            print('***************************************************************************')
         end
 
-        DisplayMenuContainer(true)
-        PlaySoundFrontend(-1, "OK", "HUD_FRONTEND_DEFAULT_SOUNDSET", 1)
-    end)
+        if not canEnter then
+            QBCore.Functions.Notify('You cant do anything here!')
+            ExitBennys()
+            return
+        end
 
-    isPlyInBennys = true
-    DisableControls(repairOnly)
+        if Config.UseRadial and radialMenuItemId then
+            exports['qb-radialmenu']:RemoveOption(radialMenuItemId)
+            radialMenuItemId = nil
+        end
+
+        exports['qb-core']:HideText()
+
+        local plyPed = PlayerPedId()
+        local plyVeh = GetVehiclePedIsIn(plyPed, false)
+        local isMotorcycle
+
+        if GetVehicleClass(plyVeh) == 8 then --Motorcycle
+            isMotorcycle = true
+        else
+            isMotorcycle = false
+        end
+
+        SetVehicleModKit(plyVeh, 0)
+        SetEntityCoords(plyVeh, ((override and override.coords) or CustomsData.coords))
+        SetEntityHeading(plyVeh, ((override and override.heading) or CustomsData.heading))
+        FreezeEntityPosition(plyVeh, true)
+        SetEntityCollision(plyVeh, false, true)
+
+        local vehicleHealth = GetVehicleBodyHealth(plyVeh)
+
+        local welcomeLabel = (locationData and locationData.settings.welcomeLabel) or "Welcome to Benny's Motorworks!"
+        InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
+
+        SetTimeout(100, function()
+            if vehicleHealth < 1000.0 and (Config.BaseRepairPrice + 1000 - vehicleHealth) > 0 and categories.repair then
+                DisplayMenu(true, "repairMenu")
+            else
+                DisplayMenu(true, "mainMenu")
+            end
+
+            DisplayMenuContainer(true)
+            PlaySoundFrontend(-1, "OK", "HUD_FRONTEND_DEFAULT_SOUNDSET", 1)
+        end)
+
+        isPlyInBennys = true
+        DisableControls(repairOnly)
+    end)
 end
 
 function DisableControls(repairOnly)

--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -751,7 +751,7 @@ function EnterLocation(override)
         end
     elseif override then canEnter = true end
 
-    QBCore.Functions.TriggerCallback('qb-customs:server:getOnDutyMechanics', function(currentMechanics)
+    QBCore.Functions.TriggerCallback('qb-vehicletuning:server:IsMechanicAvailable', function(currentMechanics)
         if currentMechanics >= Config.MinOnlineMechanics and not override and PlayerData.job.name ~= 'mechanic' then
             repairOnly = true
             for k, v in pairs(Config.DisabledCategoriesMechanics) do

--- a/config.lua
+++ b/config.lua
@@ -9,7 +9,7 @@ Config.UseRadial = false -- Will use qb-radial menu for entering instead of pres
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 
 Config.DisableWhenMechanicsOnline = false -- Disables customs completely if enough mechanics are online and on-duty
-Config.MinOnlineMechanics = 1 -- The amount of mechanics that have to be online and on-duty to disable customs
+Config.MinOnlineMechanics = 1 -- The amount of mechanics that have to be online and on-duty to disable customs (mechanics can still use them)
 Config.DisabledCategoriesMechanics = {
     repair = false,
     mods = false,

--- a/config.lua
+++ b/config.lua
@@ -8,8 +8,24 @@ Config.BaseRepairPrice = 0 -- Starting repair price. Every player's vehicle dama
 Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 
-Config.DisableWhenMechanicsOnline = false -- Disables customs if enough mechanics are online and on-duty
-Config.MinOnlineMechanics = 1 -- How many mechanics have to be online and on-duty to disable customs
+Config.DisableWhenMechanicsOnline = false -- Disables customs completely if enough mechanics are online and on-duty
+Config.MinOnlineMechanics = 1 -- The amount of mechanics that have to be online and on-duty to disable customs
+Config.DisabledCategoriesMechanics = {
+    repair = false,
+    mods = false,
+    armor = false,
+    respray = false,
+    liveries = false,
+    wheels = false,
+    tint = false,
+    plate = false,
+    extras = false,
+    neons = false,
+    xenons = false,
+    horn = false,
+    turbo = false,
+    cosmetics = false,
+} -- `true` to disable category if enough mechanics are online and on-duty, `false` to ignore
 
 maxVehiclePerformanceUpgrades = 0 -- | All Upgrades: 0 | No Upgrades: -1 | Can be -1 to 4
 


### PR DESCRIPTION
**Describe Pull request**
Adds an option to disable certain categories when mechanics are available, instead of disabling customs entirely.

Also improves some comments in the config.

Closes #147

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
