### PR TITLE
Fix error on repair with no damage and base price above 0

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -787,11 +787,13 @@ function EnterLocation(override)
     FreezeEntityPosition(plyVeh, true)
     SetEntityCollision(plyVeh, false, true)
 
+    local vehicleHealth = GetVehicleBodyHealth(plyVeh)
+
     local welcomeLabel = (locationData and locationData.settings.welcomeLabel) or "Welcome to Benny's Motorworks!"
-    InitiateMenus(isMotorcycle, GetVehicleBodyHealth(plyVeh), categories, welcomeLabel)
+    InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
 
     SetTimeout(100, function()
-        if (Config.BaseRepairPrice + 1000 - GetVehicleBodyHealth(plyVeh)) > 0 and categories.repair then
+        if vehicleHealth < 1000.0 and (Config.BaseRepairPrice + 1000 - vehicleHealth) > 0 and categories.repair then
             DisplayMenu(true, "repairMenu")
         else
             DisplayMenu(true, "mainMenu")


### PR DESCRIPTION
**Describe Pull request**
Fixed an error that occurs when trying to enter a customs with repair enabled, when the vehicle damage  is 0, and when the base price is above 0.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
