### PR TITLE
Add repair price multiplier

### DIFF
--- a/client/cl_bennys.lua
+++ b/client/cl_bennys.lua
@@ -806,7 +806,7 @@ function EnterLocation(override)
         InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
 
         SetTimeout(100, function()
-            if vehicleHealth < 1000.0 and (Config.BaseRepairPrice + 1000 - vehicleHealth) > 0 and categories.repair then
+            if vehicleHealth < 1000.0 and Config.BaseRepairPrice + ((1000 - vehicleHealth) * Config.RepairPriceMultiplier) > 0 and categories.repair then
                 DisplayMenu(true, "repairMenu")
             else
                 DisplayMenu(true, "mainMenu")

--- a/client/cl_ui.lua
+++ b/client/cl_ui.lua
@@ -204,7 +204,7 @@ function InitiateMenus(isMotorcycle, vehicleHealth, categories, welcomeLabel)
     local plyVeh = GetVehiclePedIsIn(plyPed, false)
     --#[Repair Menu]#--
     if vehicleHealth < 1000.0 and categories.repair then
-        local repairCost = math.ceil(Config.BaseRepairPrice + 1000 - vehicleHealth)
+        local repairCost = math.ceil(Config.BaseRepairPrice + ((1000 - vehicleHealth) * Config.RepairPriceMultiplier))
         if repairCost > 0 then
             TriggerServerEvent("qb-customs:server:updateRepairCost", repairCost)
             createMenu("repairMenu", welcomeLabel, "Repair Vehicle")

--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,7 @@ Config.MoneyType = 'bank'
 Config.RepairMoneyType = 'cash'
 Config.DefaultRepairPrice = 600 -- Repair price that is used if a vehicle-specific price is not available
 Config.BaseRepairPrice = 0 -- Starting repair price. Every player's vehicle damage (0-1000) is added to it later. If the final price is 0 or less, the repair menu does not appear
-Config.RepairPriceMultiplier = 1 -- Every player's vehicle damage (0-1000) is multiplier by this number, and then added to the base repair price
+Config.RepairPriceMultiplier = 1.0 -- Every player's vehicle damage (0-1000) is multiplier by this number, and then added to the base repair price
 Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 

--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,7 @@ Config.MoneyType = 'bank'
 Config.RepairMoneyType = 'cash'
 Config.DefaultRepairPrice = 600 -- Repair price that is used if a vehicle-specific price is not available
 Config.BaseRepairPrice = 0 -- Starting repair price. Every player's vehicle damage (0-1000) is added to it later. If the final price is 0 or less, the repair menu does not appear
+Config.RepairPriceMultiplier = 1 -- Every player's vehicle damage (0-1000) is multiplier by this number, and then added to the base repair price
 Config.UseRadial = false -- Will use qb-radial menu for entering instead of press E
 Config.allowGovPlateIndex = false -- Setting this to true will allow all vehicles to purchase gov plate index "Blue on White #3" (only for emergency vehicles otherwise)
 


### PR DESCRIPTION
**Describe Pull request**
Add a configurable option for multiplying the vehicle damage that gets added to the base repair price.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
